### PR TITLE
Mudança no Gerenciamento do Navigation Stack

### DIFF
--- a/haub/android/app/build.gradle
+++ b/haub/android/app/build.gradle
@@ -62,6 +62,6 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.firebase:firebase-auth:18.0.0"
+    implementation "com.google.firebase:firebase-auth:19.3.2"
     implementation "com.google.firebase:firebase-firestore:20.0.0"
 }

--- a/haub/android/settings_aar.gradle
+++ b/haub/android/settings_aar.gradle
@@ -1,9 +1,5 @@
 include ':app'
 
-
-
-
-
 def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
 
 def plugins = new Properties()

--- a/haub/lib/main.dart
+++ b/haub/lib/main.dart
@@ -1,11 +1,7 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-import 'package:haub/view/add_question/question_page.dart';
-import 'package:haub/view/chat_screen/chat_screen.dart';
-import 'package:haub/view/home/drawer.dart';
+import 'package:haub/view/home/home.dart';
 import 'package:haub/view/onboard/cadastro.dart';
 import 'package:haub/view/onboard/login.dart';
-import 'models/colorPalette.dart';
 
 void main() {
   runApp(MyApp());
@@ -27,90 +23,5 @@ class MyApp extends StatelessWidget {
       },
       //MyHomePageWidget(),
     );
-  }
-}
-
-class MyHomePageWidget extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: PreferredSize(
-          preferredSize: Size.fromHeight(100.0),
-          child: AppBar(
-            backgroundColor: ColorPalette.primaryColor,
-            title: const Text(
-              'Haub',
-              style: TextStyle(
-                fontSize: 34,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.only(
-                    bottomLeft: Radius.circular(30),
-                    bottomRight: Radius.circular(30))),
-            actions: <Widget>[
-              IconButton(
-                icon: const Icon(Icons.account_circle),
-                onPressed: () {
-                  Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (BuildContext context) => MyLoginPage()));
-                },
-              ),
-            ],
-          ),
-        ),
-        drawer: MyDrawer(),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              RaisedButton(
-                  child: Text("Navegar para o chat"),
-                  color: ColorPalette.secondaryColor,
-                  onPressed: () {
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (BuildContext context) => MyChatPage()));
-                  }),
-              RaisedButton(
-                  child: Text("Navegar para o adicionar"),
-                  color: ColorPalette.secondaryColor,
-                  onPressed: () {
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (BuildContext context) =>
-                                MyQuestionPage()));
-                  }),
-            ],
-          ),
-        ),
-        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-        floatingActionButton: FloatingActionButton(
-          backgroundColor: ColorPalette.secondaryColor,
-          onPressed: () {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (BuildContext context) => MyQuestionPage()));
-          },
-          tooltip: 'Increment',
-          child: Icon(Icons.add),
-          elevation: 2.0,
-        ),
-        bottomNavigationBar: BottomAppBar(
-            shape: CircularNotchedRectangle(),
-            notchMargin: 7.0,
-            color: ColorPalette.primaryColor,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(12, 30, 12, 10),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-              ),
-            )));
   }
 }

--- a/haub/lib/view/add_question/doubt_abstract.dart
+++ b/haub/lib/view/add_question/doubt_abstract.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../../main.dart';
+//import 'package:haub/view/home/home.dart';
 
 class MyDaubtAbstractPage extends StatelessWidget {
   MyDaubtAbstractPage({Key key}) : super(key: key);
@@ -15,10 +14,9 @@ class MyDaubtAbstractPage extends StatelessWidget {
         child: RaisedButton(
             child: Text("Finalizar"),
             onPressed: () {
-              Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (BuildContext context) => MyHomePageWidget()));
+              Navigator.popUntil(
+                context, 
+                ModalRoute.withName('/home'));
             }),
       ),
     );

--- a/haub/lib/view/home/drawer.dart
+++ b/haub/lib/view/home/drawer.dart
@@ -58,6 +58,7 @@ class MyDrawer extends StatelessWidget {
             )
           ),
           CustomListTile(Icons.account_circle, 'Perfil', (){
+              Navigator.pop(context);
               Navigator.push(context, MaterialPageRoute(
               builder: (BuildContext context) =>  MyProfileScreen()));
           }),
@@ -71,7 +72,7 @@ class MyDrawer extends StatelessWidget {
                   splashColor: ColorPalette.primaryColor,
                   color: ColorPalette.secondaryColor,
                   child: Text("Sair"),
-                  onPressed: (){},
+                  onPressed: (){Navigator.pushReplacementNamed(context, '/');}
                 ),
               ),
             ],
@@ -83,9 +84,9 @@ class MyDrawer extends StatelessWidget {
 }
 
 class CustomListTile extends StatelessWidget {
-  IconData icon;
-  String text;
-  Function onTap;
+  final IconData icon;
+  final String text;
+  final Function onTap;
 
   CustomListTile(this.icon, this.text, this.onTap);
 

--- a/haub/lib/view/home/home.dart
+++ b/haub/lib/view/home/home.dart
@@ -1,0 +1,106 @@
+//import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:haub/view/add_question/question_page.dart';
+import 'package:haub/view/chat_screen/chat_screen.dart';
+import 'package:haub/view/home/drawer.dart';
+import 'package:haub/models/colorPalette.dart';
+
+class MyHomePageWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+     Future<bool> _alertBeforeClosing() {
+      return showDialog(
+        context: context,
+        builder: (context) => new AlertDialog(
+          title: new Text('Você tem certeza?'),
+          content: new Text('Deseja fechar o aplicativo?'),
+          actions: <Widget>[
+            new GestureDetector(
+              onTap: () => Navigator.of(context).pop(false),
+              child: Text("Não"),
+            ),
+            SizedBox(height: 16),
+            new GestureDetector(
+              onTap: () => Navigator.of(context).pop(true),
+              child: Text("Sim"),
+            ),
+          ],
+        ),
+      ) ??
+          false;
+    }
+
+    return WillPopScope(
+      onWillPop: _alertBeforeClosing,
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: Size.fromHeight(100.0),
+          child: AppBar(
+            backgroundColor: ColorPalette.primaryColor,
+            title: const Text(
+              'Haub',
+              style: TextStyle(
+                fontSize: 34,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(30),
+                    bottomRight: Radius.circular(30))),
+            
+          ),
+        ),
+        drawer: MyDrawer(),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              RaisedButton(
+                  child: Text("Navegar para o chat"),
+                  color: ColorPalette.secondaryColor,
+                  onPressed: () {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (BuildContext context) => MyChatPage()));
+                  }),
+              RaisedButton(
+                  child: Text("Navegar para o adicionar"),
+                  color: ColorPalette.secondaryColor,
+                  onPressed: () {
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (BuildContext context) =>
+                                MyQuestionPage()));
+                  }),
+            ],
+          ),
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+        floatingActionButton: FloatingActionButton(
+          backgroundColor: ColorPalette.secondaryColor,
+          onPressed: () {
+            Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (BuildContext context) => MyQuestionPage()));
+          },
+          tooltip: 'Increment',
+          child: Icon(Icons.add),
+          elevation: 2.0,
+        ),
+        bottomNavigationBar: BottomAppBar(
+            shape: CircularNotchedRectangle(),
+            notchMargin: 7.0,
+            color: ColorPalette.primaryColor,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 30, 12, 10),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+              ),
+            ))),
+    );
+  }
+}

--- a/haub/lib/view/onboard/cadastro.dart
+++ b/haub/lib/view/onboard/cadastro.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:haub/models/colorPalette.dart';
 
-import '../../main.dart';
-
 class MyRegisterPage extends StatelessWidget {
   MyRegisterPage({Key key}) : super(key: key);
 

--- a/haub/lib/view/onboard/login.dart
+++ b/haub/lib/view/onboard/login.dart
@@ -12,7 +12,7 @@ class _LoginScreenState extends State<MyLoginPage> {
   final _passController = TextEditingController();
 
   final _formKey = GlobalKey<FormState>();
-  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  //final _scaffoldKey = GlobalKey<ScaffoldState>();
 
   @override
   Widget build(BuildContext context) {

--- a/haub/lib/view/onboard/onboard.dart
+++ b/haub/lib/view/onboard/onboard.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../main.dart';
+import 'package:haub/view/home/home.dart';
 
 class MyOnboardPage extends StatelessWidget {
   MyOnboardPage({Key key}) : super(key: key);

--- a/haub/lib/view/perfil/profile.dart
+++ b/haub/lib/view/perfil/profile.dart
@@ -11,6 +11,14 @@ class MyProfileScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Haub perfil'),
         backgroundColor: ColorPalette.primaryColor,
+        leading: Builder(
+          builder: (BuildContext context) {
+            return IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () {Navigator.popUntil(context, ModalRoute.withName('/home'));}
+            );
+          },
+        ),
       ),
       body: Center(
         child: RaisedButton(


### PR DESCRIPTION
- Alteração de comportamento de botões de retorno (leading Widgets);
- Criado arquivo home.dart para armazenar a página home, realocando a implementação da view home, de main.dart para home.dart;
- Alterado Drawer Tile Model para fechar o drawer após cliques;
- Removido botão "Perfil" da tela inicial;
- Adicionado fluxo de "Sair", através do botão Sair no drawer, que redireciona à página de login